### PR TITLE
Change flutter dependency to a SDK dependency

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -10,4 +10,8 @@ flutter:
     pluginClass: VideoLauncherPlugin
 
 dependencies:
-  flutter: ">=0.0.20 <0.1.0"
+  flutter:
+    sdk: flutter
+
+environment:
+    sdk: ">=1.8.0 <2.0.0"


### PR DESCRIPTION
Currently the example app fails to build:

```
mit-macbookpro2:tmp mit$ cd flutter_video_launcher/example/
mit-macbookpro2:example mit$ flutter build apk
Running "flutter packages get" in example...
Incompatible dependencies on flutter:
- video_launcher 0.2.1 depends on it from source hosted
- video_launcher_example depends on it from source sdk
pub get failed (1)
```

This resolves it by changing the Flutter dependency to an SDK dependency.